### PR TITLE
MORE-450-study-manager-frontend-show-action-buttons-inactive-instead-of-hiding

### DIFF
--- a/src/components/shared/MoreTable.vue
+++ b/src/components/shared/MoreTable.vue
@@ -658,6 +658,13 @@
 
     td.row-actions {
       justify-content: flex-end;
+      pointer-events: none;
+      .p-button {
+        pointer-events: all;
+        &.p-disabled {
+          pointer-events: none;
+        }
+      }
     }
 
     .placeholder {


### PR DESCRIPTION
remove row-actions column hover, but leave active buttons to be clickable