### PR TITLE
#420: Add the option to clone integrations.

### DIFF
--- a/src/components/ObservationList.vue
+++ b/src/components/ObservationList.vue
@@ -31,7 +31,6 @@ Licensed under the Elastic License 2.0. */
   import { useDialog } from 'primevue/usedialog';
   import ObservationDialog from '../components/dialog/ObservationDialog.vue';
   import useLoader from '../composable/useLoader';
-  import { useStudyStore } from '../stores/studyStore';
   import { useI18n } from 'vue-i18n';
   import { useErrorHandling } from '../composable/useErrorHandling';
   import DeleteMoreTableRowDialog from './dialog/DeleteMoreTableRowDialog.vue';
@@ -40,7 +39,6 @@ Licensed under the Elastic License 2.0. */
   const loader = useLoader();
   const { observationsApi } = useObservationsApi();
   const { componentsApi } = useComponentsApi();
-  const studyStore = useStudyStore();
   const { t } = useI18n();
   const { handleIndividualError } = useErrorHandling();
 
@@ -54,9 +52,9 @@ Licensed under the Elastic License 2.0. */
   });
 
   const actionsVisible =
-    studyStore.study.status === StudyStatus.Draft ||
-    studyStore.study.status === StudyStatus.Paused ||
-    studyStore.study.status === StudyStatus.PausedPreview;
+    props.studyStatus === StudyStatus.Draft ||
+    props.studyStatus === StudyStatus.Paused ||
+    props.studyStatus === StudyStatus.PausedPreview;
 
   const groupStatuses = props.studyGroups.map(
     (item) =>
@@ -343,7 +341,7 @@ Licensed under the Elastic License 2.0. */
         return openObservationDialog(
           t('observation.dialog.header.clone'),
           action.row,
-          'clone'
+          true
         );
       case 'edit':
         return openEditObservation(action.row.observationId);
@@ -398,7 +396,7 @@ Licensed under the Elastic License 2.0. */
   function openObservationDialog(
     headerText: string,
     observation?: Observation,
-    typeText?: string
+    clone?: boolean
   ) {
     dialog.open(ObservationDialog, {
       data: {
@@ -424,7 +422,7 @@ Licensed under the Elastic License 2.0. */
       onClose: (options) => {
         if (options?.data) {
           if (options.data?.observationId) {
-            if (typeText) {
+            if (clone) {
               createObservation(options.data as Observation);
             } else {
               updateObservation(options.data as Observation);

--- a/src/components/dialog/CopyTokenDialog.vue
+++ b/src/components/dialog/CopyTokenDialog.vue
@@ -11,9 +11,9 @@ Licensed under the Elastic License 2.0. */
   import IntegrationExample from '../subComponents/IntegrationExample.vue';
 
   const infoDialogRef: any = inject('dialogRef');
-  const title: string = infoDialogRef?.value?.data?.title;
-  const message: string = infoDialogRef?.value?.data?.message;
-  const token: string = infoDialogRef?.value?.data?.highlightMsg;
+  const title: string = infoDialogRef.value.data.title;
+  const message: string = infoDialogRef.value.data.message;
+  const token: string = infoDialogRef.value.data.highlightMsg;
 
   const { t } = useI18n();
   const showMessage: Ref<boolean> = ref(false);
@@ -32,8 +32,10 @@ Licensed under the Elastic License 2.0. */
   <div class="info-dialog">
     <h5 class="mb-2">{{ title }}</h5>
     <div class="mb-4">{{ message }}</div>
-    <div class="h6 color-primary font-medium">{{ token }}</div>
-    <IntegrationExample />
+    <div class="h6 color-primary cursor-pointer font-medium" @click="copyToken">
+      {{ token }}
+    </div>
+    <IntegrationExample :token="token" />
     <div class="mt-8 flex justify-end">
       <Button type="button" class="btn-gray" @click="closeDialog">{{
         $t('global.labels.close')

--- a/src/components/subComponents/IntegrationExample.vue
+++ b/src/components/subComponents/IntegrationExample.vue
@@ -3,7 +3,14 @@ license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
 Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
 Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
 Licensed under the Elastic License 2.0. */
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  const props = defineProps({
+    token: {
+      type: String,
+      default: 'ef1e9877-7ab1-49b7-bf7e-b35952cfa32c',
+    },
+  });
+</script>
 
 <template>
   <div class="integration-example">
@@ -41,7 +48,7 @@ Licensed under the Elastic License 2.0. */
           https://data.platform-test.more.redlink.io/api/v1/external/bulk \
           <br />
           -H "Content-Type: application/json" \ <br />
-          -H "More-Api-Token: ef1e9877-7ab1-49b7-bf7e-b35952cfa32c" \ <br />
+          -H "More-Api-Token: {{ props.token }}" \ <br />
           -d
           '{"participantId":"2","dataPoints":[{"dataId":"3","dataValue":{"value":1,"something":"sth"},"timestamp":"2023-05-23T11:55:05.366Z"}]}'
         </small>
@@ -72,7 +79,7 @@ Licensed under the Elastic License 2.0. */
           curl -X GET
           https://data.platform-test.more.redlink.io/api/v1/external/participants
           \ <br />
-          -H "More-Api-Token: ef1e9877-7ab1-49b7-bf7e-b35952cfa32c"
+          -H "More-Api-Token: {{ props.token }}"
         </small>
       </code>
     </div>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -513,6 +513,7 @@
     "dialog": {
       "header": {
         "delete": "Integration löschen",
+        "clone": "Integration klonen",
         "create": "Integration erstellen",
         "tokenCopy": "Token kopieren"
       },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -513,6 +513,7 @@
     "dialog": {
       "header": {
         "delete": "Delete integration",
+        "clone": "Clone integration",
         "create": "Create integration",
         "tokenCopy": "Copy token"
       },

--- a/src/views/Integrations.vue
+++ b/src/views/Integrations.vue
@@ -5,9 +5,7 @@ Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
 Licensed under the Elastic License 2.0. */
 <script setup lang="ts">
   import MoreTabNav from '../components/shared/MoreTabNav.vue';
-  // integrationList
   import StudyHeader from '../components/shared/StudyHeader.vue';
-  import { StudyStatus } from '../generated-sources/openapi';
   import { useStudyStore } from '../stores/studyStore';
   import IntegrationList from '../components/IntegrationList.vue';
 
@@ -25,7 +23,7 @@ Licensed under the Elastic License 2.0. */
     <Suspense>
       <IntegrationList
         :study-id="studyStore.studyId"
-        :actions-visible="studyStore.study.status !== StudyStatus.Closed"
+        :study-status="studyStore.studyStatus"
       />
     </Suspense>
   </div>


### PR DESCRIPTION
Add the option to clone integrations as it is already possible for observations and interventions.

* Unify code structure.
* Show generated token instead of hard coded token in CopyTokenDialog.
* Add copy to clipboard when you click on the generated token in the CopyTokenDialog.

#420 