### PR TITLE
#420: Allow to edit the integration label, when the study is not closed.

### DIFF
--- a/openapi/StudyManagerAPI.yaml
+++ b/openapi/StudyManagerAPI.yaml
@@ -789,6 +789,33 @@ paths:
         '404':
           description: not found
 
+    put:
+      tags:
+        - observations
+      description: Update label from observation endpoint token
+      operationId: updateTokenLabel
+      parameters:
+        - $ref: '#/components/parameters/StudyId'
+        - $ref: '#/components/parameters/ObservationId'
+        - $ref: '#/components/parameters/TokenId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenLabel'
+      responses:
+        '200':
+          description: Token label successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EndpointToken'
+
+        '400':
+          description: could not update observation
+        '404':
+          description: not found
 
     delete:
       tags:

--- a/openapi/StudyManagerAPI.yaml
+++ b/openapi/StudyManagerAPI.yaml
@@ -738,7 +738,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenLabel'
+              $ref: '#/components/schemas/EndpointToken'
       responses:
         '201':
           description: Token successfully added
@@ -803,7 +803,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TokenLabel'
+              $ref: '#/components/schemas/EndpointToken'
       responses:
         '200':
           description: Token label successfully updated
@@ -1626,21 +1626,19 @@ components:
         tokenId:
           $ref: '#/components/schemas/Id'
         tokenLabel:
-          $ref: '#/components/schemas/TokenLabel'
+          type: string
         created:
           type: string
           format: date-time
           readOnly: true
         token:
           type: string
+          readOnly: true
       required:
         - tokenId
         - tokenLabel
         - created
         - token
-
-    TokenLabel:
-      type: string
 
     ParticipationData:
       type: object

--- a/src/components/IntegrationList.vue
+++ b/src/components/IntegrationList.vue
@@ -224,7 +224,12 @@ Licensed under the Elastic License 2.0. */
         props.studyId,
         integration.observationId,
         integration.tokenId,
-        integration.tokenLabel,
+        {
+          tokenId: integration.tokenId,
+          tokenLabel: integration.tokenLabel,
+          created: integration.created,
+          token: '',
+        } as EndpointToken,
       )
       .catch((e: AxiosError) =>
         handleIndividualError(
@@ -291,11 +296,12 @@ Licensed under the Elastic License 2.0. */
 
   async function createIntegration(integrationCreate: MoreIntegrationLink) {
     await observationsApi
-      .createToken(
-        props.studyId,
-        integrationCreate.observationId,
-        integrationCreate.tokenLabel,
-      )
+      .createToken(props.studyId, integrationCreate.observationId, {
+        tokenId: 0,
+        tokenLabel: integrationCreate.tokenLabel,
+        created: '',
+        token: '',
+      } as EndpointToken)
       .then((response) => {
         openInfoDialog(response.data);
         listIntegrations();

--- a/src/components/IntegrationList.vue
+++ b/src/components/IntegrationList.vue
@@ -58,6 +58,7 @@ Licensed under the Elastic License 2.0. */
       field: 'tokenLabel',
       header: t('integration.props.tokenLabel'),
       sortable: true,
+      editable: true,
     },
     {
       field: 'observationId',
@@ -209,6 +210,30 @@ Licensed under the Elastic License 2.0. */
     }
   }
 
+  async function updateIntegration(integration: MoreIntegrationTableMap) {
+    const i = integrationList.value.findIndex(
+      (o: MoreIntegrationTableMap) =>
+        o.observationId === integration.observationId,
+    );
+    if (i > -1) {
+      integrationList.value[i] = integration;
+    }
+
+    await observationsApi
+      .updateTokenLabel(
+        props.studyId,
+        integration.observationId,
+        integration.tokenId,
+        integration.tokenLabel,
+      )
+      .catch((e: AxiosError) =>
+        handleIndividualError(
+          e,
+          `Couldn't update integration ${integration.observationTitle}`,
+        ),
+      );
+  }
+
   async function openIntegrationDialog(headerText: string) {
     dialog.open(IntegrationDialog, {
       data: {
@@ -326,11 +351,12 @@ Licensed under the Elastic License 2.0. */
       :row-actions="rowActions"
       :table-actions="tableActions"
       :loading="loader.isLoading.value"
-      :editable-access="false"
+      :editable-access="actionsVisible"
       :editable-user-roles="[StudyRole.Admin, StudyRole.Operator]"
       :empty-message="$t('integration.integrationList.emptyListMsg')"
       class="table-title-width table-btn-min-height"
       @onaction="execute($event)"
+      @onchange="updateIntegration($event)"
     />
     <DynamicDialog />
   </div>

--- a/src/components/dialog/IntegrationDialog.vue
+++ b/src/components/dialog/IntegrationDialog.vue
@@ -43,10 +43,7 @@ Licensed under the Elastic License 2.0. */
   const selectedObservation: Ref<MoreTableChoice | null> = ref(null);
   const tokenLabel: Ref<string> = ref('');
 
-  const editable =
-    studyStore.study.status === StudyStatus.Draft ||
-    studyStore.study.status === StudyStatus.Paused ||
-    studyStore.study.status === StudyStatus.PausedPreview;
+  const editable = studyStore.study.status !== StudyStatus.Closed;
 
   const errors: Ref<Array<MoreTableChoice>> = ref([]);
 


### PR DESCRIPTION
* It is now possible to edit the integration token label in all study states, except closed.
* Allow to edit the integration in the More Table (only tokenLabel).
* Add new API call "updateIntegration" to edit the integration label.

Needs BE change: https://github.com/MORE-Platform/more-studymanager-backend/pull/295