### PR TITLE
#376 Fix multiple issues.

### DIFF
--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -478,7 +478,10 @@ Licensed under the Elastic License 2.0. */
       <div class="vuecal__event-title">
         {{ event.title }}
         <span
-          v-if="!event.allDay && event.class !== 'participant-joined'"
+          v-if="
+            !event.allDay &&
+            !['participant-joined', 'intervention'].includes(event.class)
+          "
           class="pi mr-0.5"
           :class="event.cHidden ? 'pi-eye-slash' : 'pi-eye'"
         >
@@ -508,28 +511,26 @@ Licensed under the Elastic License 2.0. */
 </template>
 
 <style scoped lang="postcss">
-  .vuecal >>> {
-    .vuecal__event {
-      &.observation {
-        background-color: var(--green-100);
-        border: 1px solid var(--primary-200);
-      }
-      &.intervention {
-        background-color: var(--yellow-100);
-        border: 1px solid var(--primary-200);
-      }
-      &.study-date {
-        background-color: var(--primary-500);
-        color: white;
-      }
-      &.study-range {
-        background-color: var(--primary-200);
-        color: white;
-      }
-      &.participant-joined {
-        background-color: var(--red-600);
-        color: white;
-      }
+  .vuecal :deep(.vuecal__event) {
+    &.observation {
+      background-color: var(--green-100);
+      border: 1px solid var(--primary-200);
+    }
+    &.intervention {
+      background-color: var(--yellow-100);
+      border: 1px solid var(--primary-200);
+    }
+    &.study-date {
+      background-color: var(--primary-500);
+      color: white;
+    }
+    &.study-range {
+      background-color: var(--primary-200);
+      color: white;
+    }
+    &.participant-joined {
+      background-color: var(--red-600);
+      color: white;
     }
   }
 </style>

--- a/src/components/shared/Scheduler.vue
+++ b/src/components/shared/Scheduler.vue
@@ -65,7 +65,9 @@ Licensed under the Elastic License 2.0. */
   }
 
   const singleDayEventCheckbox: Ref<boolean> = ref(
-    calendarStart.value.getDay() === calendarEnd.value.getDay() ? true : false,
+    calendarStart.value.getDate() === calendarEnd.value.getDate() &&
+      calendarStart.value.getMonth() === calendarEnd.value.getMonth() &&
+      calendarStart.value.getFullYear() === calendarEnd.value.getFullYear(),
   ); // Individual Observation Checkbox
   const hasRruleValue: Ref<boolean> = ref(
     !returnSchedule.value.rrule ? false : true,

--- a/src/components/subComponents/AbsoluteSchedulerRepetition.vue
+++ b/src/components/subComponents/AbsoluteSchedulerRepetition.vue
@@ -206,7 +206,7 @@
     }
   });
 
-  function onChangeRrule(type?: string) {
+  function onChangeRrule(type?: string, eventValue?: any) {
     if (
       type === 'byday' &&
       previewCount.value &&
@@ -220,8 +220,11 @@
       emit('onRruleChange', returnRrule.value);
     }
 
-    if (type === 'count' && !previewCount.value) {
-      returnRrule.value.count = undefined;
+    if (type === 'count') {
+      previewCount.value = eventValue;
+      if (!previewCount.value) {
+        returnRrule.value.count = undefined;
+      }
     }
 
     if (returnRrule.value.freq === Frequency.Daily && returnRrule.value.byday) {
@@ -323,8 +326,7 @@
               <InputNumber
                 v-model="previewCount"
                 :placeholder="$t('scheduler.placeholder.enterRepeatCount')"
-                @input="onChangeRrule('count')"
-                @blur="onChangeRrule('count')"
+                @input="onChangeRrule('count', $event.value)"
               />
               <span class="ml-2">{{ rruleCountLabel }}</span>
             </div>

--- a/src/components/subComponents/SchedulerInfoBlock.vue
+++ b/src/components/subComponents/SchedulerInfoBlock.vue
@@ -150,7 +150,7 @@ Licensed under the Elastic License 2.0. */
                   ? `${t('scheduler.preview.title.in')} ${repetitionCount} ${t(
                       `scheduler.preview.unit.${schedule.rrule.freq}`,
                     )}`
-                  : undefined;
+                  : t('scheduler.labels.event.repetitionEnd.studyEnd');
               }
             }
           }

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -694,7 +694,7 @@
 
   "timeline": {
     "labels": {
-      "relativeDate": "Relatives Startdatum",
+      "relativeDate": "Relatives Datum des Studienbeginns",
       "studyStart": "Studienstart",
       "studyEnd": "Studienende",
       "plannedStart": "Geplanter Start",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -692,7 +692,7 @@
 
   "timeline": {
     "labels": {
-      "relativeDate": "Relative Date",
+      "relativeDate": "Relative study start date",
       "studyStart": "Study start",
       "studyEnd": "Study end",
       "plannedStart": "Planned Start",

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -13,6 +13,7 @@ import { useImportExportApi, useStudiesApi } from '../composable/useApi';
 import { AxiosError, AxiosResponse } from 'axios';
 import { useErrorHandling } from '../composable/useErrorHandling';
 import { useStudyGroupStore } from './studyGroupStore';
+import { dateToDateString } from '../utils/dateUtils';
 
 export const useStudyStore = defineStore('study', () => {
   const { studiesApi } = useStudiesApi();
@@ -72,7 +73,7 @@ export const useStudyStore = defineStore('study', () => {
                   status === StudyStatus.Active ||
                   status === StudyStatus.Preview
                 ) {
-                  study.value.start = new Date().toISOString();
+                  study.value.start = dateToDateString(new Date());
                 } else if (status === StudyStatus.Draft) {
                   study.value.start = undefined;
                 }


### PR DESCRIPTION
* Changed value in InputNumber input was not considered when onChangeRrule was called, which leads to wrong validations (error msg was shown, even when we entered a number).
* Change translation to be more precise.
* Instead of checking with getDay() if the week day is the same for calendarStart and calendarEnd date, the check is stricter and takes day, month and year into account. With this change faulty configurations are not possible anymore.
* Add text to SchedulerInfoBlock when we want an observation until the end of study, which means now the until date is null, but we still need to show in the info block the information.
* When we change the study status, the start date was set with time, but this leads to an invalid timeline API call (date-time vs date object), now only the necessary date is set.
* Change the CSS selector to get rid of the >>> selector is deprecated warning in the dev console.
* Do not show the hidden icon for interventions, because they are never hidden.