### PR TITLE
#434: Show specific error message in FE via Toast pop up.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,10 +4,15 @@ Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
 Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
 Licensed under the Elastic License 2.0. */
 <script setup lang="ts">
+  import { ref, provide } from 'vue';
+  import Toast from 'primevue/toast';
   import Footer from './components/shared/Footer.vue';
   import Header from './components/shared/Header.vue';
   import { useRouter } from 'vue-router';
+
   const router = useRouter();
+  const toast = ref<Toast | null>(null);
+  provide('toast', toast);
 
   router.beforeEach((to) => {
     document.title = to.meta?.title ? to.meta.title + ' (More)' : 'More';
@@ -18,6 +23,7 @@ Licensed under the Elastic License 2.0. */
   <Header />
   <main class="mb-20 pt-14">
     <router-view />
+    <Toast ref="toast" />
   </main>
   <Footer />
 </template>

--- a/src/components/TimelineList.vue
+++ b/src/components/TimelineList.vue
@@ -430,7 +430,6 @@ Licensed under the Elastic License 2.0. */
         setupObservationAndInterventionFilterOptions(response.data);
       })
       .catch((e: AxiosError) => {
-        console.log(e);
         handleIndividualError(e, 'cannot list studyTimeline');
       });
   }

--- a/src/components/dialog/shared/BooleanPropertyInput.vue
+++ b/src/components/dialog/shared/BooleanPropertyInput.vue
@@ -31,9 +31,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="flex flex-col gap-1">
     <h5 class="font-bold">
-      <label v-if="property.name" :for="property.id"
-        >{{ $t(property.name) }}<span v-if="property.required">*</span></label
-      >
+      <label v-if="property.name" :for="property.id">
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h5>
     <div v-if="props.property.description" :id="`${property.id}-help`">
       {{ $t(props.property.description) }}
@@ -44,6 +44,7 @@ Licensed under the Elastic License 2.0. */
         v-model="booleanChecked"
         :label="property.name"
         class="mr-2"
+        :required="property.required"
         :binary="true"
         @change="emit('onBooleanChange', booleanChecked)"
       />

--- a/src/components/dialog/shared/IntegerPropertyInput.vue
+++ b/src/components/dialog/shared/IntegerPropertyInput.vue
@@ -31,9 +31,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="gap-1">
     <h5 class="font-bold">
-      <label :for="property.id"
-        >{{ $t(property.name) }}<span v-if="property.required">*</span></label
-      >
+      <label :for="property.id">
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h5>
 
     <div v-if="props.property.description" :id="`${property.id}-help`">
@@ -44,6 +44,7 @@ Licensed under the Elastic License 2.0. */
       :id="property.id"
       v-model="property.value"
       type="number"
+      :required="property.required"
       :max="property.max"
       :min="property.min"
       :disabled="!editable"

--- a/src/components/dialog/shared/ObservationPropertyInput.vue
+++ b/src/components/dialog/shared/ObservationPropertyInput.vue
@@ -69,9 +69,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="flex flex-col gap-1">
     <h6 class="font-bold">
-      <label v-if="property.name" :for="property.id"
-        >{{ $t(property.name) }}<span v-if="property.required">*</span></label
-      >
+      <label v-if="property.name" :for="property.id">
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h6>
     <Dropdown
       :id="property.id"
@@ -79,6 +79,7 @@ Licensed under the Elastic License 2.0. */
       :options="observationList"
       option-label="title"
       class="w-full"
+      :required="property.required"
       :aria-describedby="`${property.id}-help`"
       :disabled="!editable"
       :placeholder="$t(props.property.description)"

--- a/src/components/dialog/shared/StringListPropertyInput.vue
+++ b/src/components/dialog/shared/StringListPropertyInput.vue
@@ -40,10 +40,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="flex flex-col gap-1">
     <h6 class="font-bold">
-      <label
-        >{{ $t(property.name) }}<span v-if="property.required">*</span
-        ><span v-if="property.required">*</span></label
-      >
+      <label>
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h6>
     <div>{{ $t(props.property.description) }}</div>
     <div v-if="editable" class="flex w-full flex-col gap-1">
@@ -54,6 +53,7 @@ Licensed under the Elastic License 2.0. */
         :class="!editable && property.value?.[index - 1] ? 'w-fit' : 'hidden'"
         :value="property.value?.[index - 1]"
         type="text"
+        :required="property.required"
         :disabled="!editable"
         :placeholder="t('global.labels.option', { value: index })"
         style="display: block"

--- a/src/components/dialog/shared/StringPropertyInput.vue
+++ b/src/components/dialog/shared/StringPropertyInput.vue
@@ -31,9 +31,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="flex flex-col gap-1">
     <h6 class="font-bold">
-      <label v-if="property.name" :for="property.id"
-        >{{ $t(property.name) }}<span v-if="property.required">*</span></label
-      >
+      <label v-if="property.name" :for="property.id">
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h6>
     <div v-if="props.property.description" :id="`${property.id}-help`">
       {{ $t(props.property.description) }}
@@ -41,9 +41,10 @@ Licensed under the Elastic License 2.0. */
 
     <InputText
       :id="property.id"
-      v-model="property.value"
+      v-model.trim="property.value"
       type="text"
       class="w-full"
+      :required="property.required"
       :aria-describedby="`${property.id}-help`"
       :disabled="!editable"
       :placeholder="

--- a/src/components/dialog/shared/StringTextPropertyInput.vue
+++ b/src/components/dialog/shared/StringTextPropertyInput.vue
@@ -31,9 +31,9 @@ Licensed under the Elastic License 2.0. */
 <template>
   <div class="flex flex-col gap-1">
     <h6 class="font-bold">
-      <label v-if="property.name" :for="property.id"
-        >{{ $t(property.name) }}<span v-if="property.required">*</span></label
-      >
+      <label v-if="property.name" :for="property.id">
+        {{ $t(property.name) }}<span v-if="property.required">*</span>
+      </label>
     </h6>
     <div v-if="props.property.description" :id="`${property.id}-help`">
       {{ $t(props.property.description) }}
@@ -44,6 +44,7 @@ Licensed under the Elastic License 2.0. */
       v-model="property.value"
       type="text"
       class="w-full"
+      :required="property.required"
       :aria-describedby="`${property.id}-help`"
       :disabled="!editable"
       :placeholder="

--- a/src/composable/toastService.ts
+++ b/src/composable/toastService.ts
@@ -1,0 +1,114 @@
+/*
+ Copyright LBI-DHP and/or licensed to LBI-DHP under one or more
+ contributor license agreements (LBI-DHP: Ludwig Boltzmann Institute
+ for Digital Health and Prevention -- A research institute of the
+ Ludwig Boltzmann Gesellschaft, Oesterreichische Vereinigung zur
+ Foerderung der wissenschaftlichen Forschung).
+ Licensed under the Elastic License 2.0.
+ */
+import { inject, Ref } from 'vue';
+import { ToastServiceMethods } from 'primevue/toastservice';
+import { ToastMessageOptions } from 'primevue/toast';
+import { useI18n } from 'vue-i18n';
+import {
+  ValidationReport,
+  ValidationReportItem,
+} from '../generated-sources/openapi';
+
+/**
+ * This composable is responsible for showing errors from Backend to the Client with a Toast popup.
+ */
+export function useToastService(): any {
+  const toast: Ref<ToastServiceMethods> | undefined =
+    inject<Ref<ToastServiceMethods>>('toast');
+  const { t } = useI18n();
+
+  if (!toast) {
+    throw new Error('ToastService is not provided');
+  }
+
+  const handleToastErrors = (err: any): void => {
+    processConfigurationException(err);
+    processOtherExceptions(err);
+  };
+
+  function processConfigurationException(report: ValidationReport): void {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    report.errors?.forEach((error: ValidationReportItem) => {
+      const errorMessage = error.message
+        ? t(error.message, { value: error.propertyId })
+        : null;
+      if (errorMessage) {
+        errors.push(errorMessage);
+      }
+    });
+
+    report.warnings?.forEach((warning: ValidationReportItem) => {
+      const warningMessage = warning.message
+        ? t(warning.message, { value: warning.propertyId })
+        : null;
+      if (warningMessage) {
+        warnings.push(warningMessage);
+      }
+    });
+
+    if (errors.length) {
+      showErrorToast(errors.join('\n'));
+    }
+
+    if (warnings.length) {
+      showWarningToast(warnings.join('\n'));
+    }
+  }
+
+  function processOtherExceptions(error: any): void {
+    if (error.message) {
+      showErrorToast(error.message);
+    }
+  }
+
+  const showToast = (
+    severity: ToastMessageOptions['severity'],
+    summary: string,
+    detail: string,
+  ): void => {
+    if (toast.value) {
+      toast.value.add({ severity, summary, detail });
+    } else {
+      console.error('Toast reference is not set');
+    }
+  };
+
+  const showErrorToast = (detail: string): void => {
+    if (toast.value) {
+      const severity: ToastMessageOptions['severity'] = 'error';
+      const summary = t('global.error.type.error');
+      const life: ToastMessageOptions['life'] = 5000;
+
+      toast.value.add({ severity, summary, detail, life });
+    } else {
+      console.error('Toast reference is not set');
+    }
+  };
+
+  const showWarningToast = (detail: string): void => {
+    if (toast.value) {
+      const severity: ToastMessageOptions['severity'] = 'warn';
+      const summary = t('global.error.type.warning');
+      const life: ToastMessageOptions['life'] = 5000;
+
+      toast.value.add({ severity, summary, detail, life });
+    } else {
+      console.error('Toast reference is not set');
+    }
+  };
+
+  return {
+    handleToastErrors,
+    showToast,
+    showErrorToast,
+    showWarningToast,
+  };
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -55,6 +55,16 @@
     },
     "footer": {
       "aboutMore": "Über More"
+    },
+    "error": {
+      "type": {
+        "error": "Fehler",
+        "warning": "Warnung",
+        "info": "Info"
+      },
+      "general": "Ein allgemeiner Fehler ist aufgetreten.",
+      "required": "Erforderlicher Wert '{value}' fehlt.",
+      "immutable": "Der Wert von '{value}' darf nicht geändert werden."
     }
   },
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -55,6 +55,16 @@
     },
     "footer": {
       "aboutMore": "About More"
+    },
+    "error": {
+      "type": {
+        "error": "Error",
+        "warning": "Warning",
+        "info": "Info"
+      },
+      "general": "A General error occurred.",
+      "required": "Required value '{value}' missing.",
+      "immutable": "The value '{value}' is immutable and cannot be changed."
     }
   },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import PrimeVue from 'primevue/config';
 import Tooltip from 'primevue/tooltip';
 import ConfirmationService from 'primevue/confirmationservice';
 import DialogService from 'primevue/dialogservice';
+import ToastService from 'primevue/toastservice';
 // Router
 import { Router } from './router';
 import AuthService from './service/AuthService';
@@ -106,6 +107,7 @@ app.use(Router);
 app.use(PrimeVue);
 app.use(ConfirmationService);
 app.use(DialogService);
+app.use(ToastService);
 app.use(pinia);
 
 app.mount('#app');

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -14,13 +14,14 @@ import { AxiosError, AxiosResponse } from 'axios';
 import { useErrorHandling } from '../composable/useErrorHandling';
 import { useStudyGroupStore } from './studyGroupStore';
 import { DownloadData } from '../models/DataDownloadModel';
+import { useToastService } from '../composable/toastService';
 
 export const useStudyStore = defineStore('study', () => {
   const { studiesApi } = useStudiesApi();
   const { importExportApi } = useImportExportApi();
   const { handleIndividualError } = useErrorHandling();
   const studyGroupStore = useStudyGroupStore();
-
+  const { handleToastErrors } = useToastService();
   // State
   const study: Ref<Study> = ref({});
   const studies: Ref<Study[]> = ref([]);
@@ -58,15 +59,11 @@ export const useStudyStore = defineStore('study', () => {
           study.value.status = status;
         })
         .catch((e: AxiosError) => {
-          alert(
-            `Could not update study status: ${
-              (e.response?.data as any)?.message
-            }`,
-          );
           handleIndividualError(
             e,
             `Could not update study status ${study.value.studyId}`,
           );
+          handleToastErrors(e.response?.data);
         });
     }
   }

--- a/src/styles/more-light/theme.pcss
+++ b/src/styles/more-light/theme.pcss
@@ -5356,7 +5356,6 @@
 }
 .p-toast .p-toast-message .p-toast-message-content {
   padding: var(--content-padding);
-  border-width: 0 0 0 6px;
 }
 .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
   margin: 0 0 0 var(--content-padding);

--- a/src/views/StudyOverview.vue
+++ b/src/views/StudyOverview.vue
@@ -13,17 +13,25 @@ Licensed under the Elastic License 2.0. */
   import { useStudyStore } from '../stores/studyStore';
   import { useStudyGroupStore } from '../stores/studyGroupStore';
   import { StudyStatus } from '../generated-sources/openapi';
+  import { AxiosError } from 'axios';
+  import { useToastService } from '../composable/toastService';
 
+  const { handleToastErrors } = useToastService();
   const route = useRoute();
   const studyStore = useStudyStore();
   const studyGroupStore = useStudyGroupStore();
   const studyId = parseInt(route.params.studyId as string);
 
   async function processUpdatedStudyStatus(status: StudyStatus): Promise<void> {
-    await studyStore.updateStudyStatus(status).then(() => {
-      // To update the start/plannedStart/end Date in the UI immediately
-      studyStore.getStudy(studyId);
-    });
+    await studyStore
+      .updateStudyStatus(status)
+      .then(() => {
+        // To update the start/plannedStart/end Date in the UI immediately
+        studyStore.getStudy(studyId);
+      })
+      .catch((e: AxiosError) => {
+        handleToastErrors(e.response?.data);
+      });
   }
 
   studyStore.getStudy(studyId);


### PR DESCRIPTION
* If you want to start a study with e.g. an empty lime survey id, a Toast pop up will be shown, that the ID is missing.
* Add global Toast component to show erroneous API response.
* Add html required attribute if property is required (not only a * symbol next to the label).
* Add trim to v-model for String properties, to trim whitespaced on users input.
* Add error translations.
* Replace alter messages with Toast pop ups.