### PR TITLE
#532: Fix scheduler offset default, improve i18n, and refactor code

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:unit:once": "vitest --environment jsdom run --outputFile.junit=target/testResults.xml --reporter=junit --reporter=default",
     "generate:api": "rm -r -f src/generated-sources && openapi-generator-cli generate",
     "license:check": "licensee --production --errors-only",
-    "license:list": "licensee --production || true"
+    "license:list": "licensee --production || true",
+    "lint:test:package": "npm run lint && npm run test:unit:once && npm run package"
   },
   "engines": {
     "node": "18.18.0",

--- a/src/components/ParticipantList.vue
+++ b/src/components/ParticipantList.vue
@@ -18,8 +18,8 @@ Licensed under the Elastic License 2.0. */
   import {
     Participant,
     StudyGroup,
-    StudyStatus,
     StudyRole,
+    StudyStatus,
   } from '../generated-sources/openapi';
   import MoreTable from './shared/MoreTable.vue';
   import ConfirmDialog from 'primevue/confirmdialog';
@@ -364,6 +364,7 @@ Licensed under the Elastic License 2.0. */
   }
 
   const menu = ref();
+
   function toggleButtonMenu(event: MouseEvent): void {
     menu.value.toggle(event);
   }

--- a/src/components/dialog/StudyDialog.vue
+++ b/src/components/dialog/StudyDialog.vue
@@ -245,12 +245,7 @@ Licensed under the Elastic License 2.0. */
             :placeholder="$t('study.placeholder.durationInput')"
             :auto-resize="true"
             :min="0"
-            @input="
-              (event) => {
-                console.log(event);
-                clearError('duration');
-              }
-            "
+            @input="clearError('duration')"
           />
           <span class="w-fit">
             {{ $t('scheduler.frequency.days') }}

--- a/src/components/shared/RelativeScheduler.vue
+++ b/src/components/shared/RelativeScheduler.vue
@@ -45,7 +45,7 @@
   );
 
   const endOffset = ref<Duration>({
-    value: schedule.dtend?.offset?.value ?? 2,
+    value: schedule.dtend?.offset?.value ?? 1,
     unit: DurationUnitEnum.Day,
   });
   const endTime = ref<DateTime>(

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -1063,7 +1063,7 @@
             "endAfter": "Bitte geben Sie den Offset zum Enddatum ein.",
             "notValid": "Die eingegebenen Werte sind ungültig.",
             "repetitionTooLong": "Wiederholungen dürfen das Studienende nicht überschreiten. Das maximale Intervall beträgt {repValue} {repUnit}.",
-            "repetitionEndTooLong": "Das Ende der Wiederholungen darf die Studiendauer von {durValue} {durUnit} nicht überschreiten."
+            "repetitionEndTooLong": "Das Ende der Wiederholungen darf die verbleibende Studiendauer von {durValue} {durUnit} nicht überschreiten."
           },
           "cannotRepeat": "Das Datenerhebungs-Event kann nicht erneut stattfinden, da dies über das Ende der Studie hinausgehen würde."
         }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1063,7 +1063,7 @@
             "endAfter": "Fill in the offset to the end date.",
             "notValid": "Values entered are not valid",
             "repetitionTooLong": "Repetitions must not exceed the end of the study. The maximum interval is {repValue} {repUnit}.",
-            "repetitionEndTooLong": "The end of repetitions must not exceed the study duration of {durValue} {durUnit}."
+            "repetitionEndTooLong": "The end of repetitions must not exceed the remaining study duration of {durValue} {durUnit}."
           },
           "cannotRepeat": "The observation cannot occur again as it would exceed the end of the study."
         }

--- a/src/utils/relativeScheduleUtils.ts
+++ b/src/utils/relativeScheduleUtils.ts
@@ -114,7 +114,7 @@ export const correctEventRepetition = (
   let frequencyEndError: ErrorValue | undefined;
 
   const timeRemaining =
-    maxDurationInMinutes - (valueToMinutes(offsetStart) - minutesInDay);
+    maxDurationInMinutes - (valueToMinutes(offsetEnd) - minutesInDay);
   if (frequencyEndInMinutes > timeRemaining) {
     correctedFrequencyEnd = minutesToDuration(timeRemaining, frequencyEnd.unit);
     frequencyEndInMinutes = timeRemaining;


### PR DESCRIPTION
Updated scheduler's end offset default value and adjusted related i18n strings for clarity. Added a new npm script for lint and test checks, streamlined input handling in StudyDialog, and corrected logic in relative schedule utility calculations. Minor reordering of imports and cleanup in various components.