### PR TITLE
#418: Remove export calendar functionality from studies module

### DIFF
--- a/src/components/StudyList.vue
+++ b/src/components/StudyList.vue
@@ -165,16 +165,6 @@ Licensed under the Elastic License 2.0. */
       visible: (study: Study) =>
         !!study.userRoles?.some((r: any) => [StudyRole.Admin].includes(r)),
     },
-    {
-      id: 'exportCalendar',
-      label: t('study.studyList.labels.exportStudyCalendar'),
-      icon: 'pi pi-calendar',
-      tooltip: t('study.studyList.labels.exportStudyCalendar'),
-      visible: (study: Study) =>
-        !!study.userRoles?.some((r: any) =>
-          [StudyRole.Admin, StudyRole.Operator].includes(r),
-        ),
-    },
   ];
 
   const endRowActions: MoreTableAction[] = [
@@ -214,9 +204,6 @@ Licensed under the Elastic License 2.0. */
         break;
       case 'exportData':
         onExportStudyData(row.studyId as number);
-        break;
-      case 'exportCalendar':
-        onExportStudyCalendar(row.studyId as number);
         break;
       case 'copyId':
         onCopyId(row.studyId, row.title);
@@ -275,10 +262,6 @@ Licensed under the Elastic License 2.0. */
 
   function onExportStudyData(studyId: number): void {
     studyStore.exportStudyData({ studyId } as DownloadData);
-  }
-
-  function onExportStudyCalendar(studyId: number): void {
-    studyStore.exportStudyCalendar(studyId);
   }
 
   function onImportStudy(event: FileUploadUploaderEvent): void {

--- a/src/stores/studyStore.ts
+++ b/src/stores/studyStore.ts
@@ -36,6 +36,7 @@ export const useStudyStore = defineStore('study', () => {
         return study.value;
       });
   }
+
   async function updateStudy(studyResponse: Study): Promise<void> {
     if (study.value.studyId) {
       study.value = await studiesApi
@@ -95,6 +96,7 @@ export const useStudyStore = defineStore('study', () => {
         );
     }
   }
+
   async function listStudies(): Promise<void> {
     studies.value = await studiesApi
       .listStudies()
@@ -104,6 +106,7 @@ export const useStudyStore = defineStore('study', () => {
         return studies.value;
       });
   }
+
   async function updateStudyInStudies(changedStudy: Study): Promise<void> {
     const i = studies.value.findIndex(
       (studyItem) => studyItem.studyId === changedStudy.studyId,
@@ -175,10 +178,6 @@ export const useStudyStore = defineStore('study', () => {
       });
   }
 
-  function exportStudyCalendar(studyId: number): void {
-    window.open(`api/v1/studies/${studyId}/calendar.ics`);
-  }
-
   function downloadJSON(filename: string, file: File): void {
     const fileJSON = JSON.stringify(file);
     const link = document.createElement('a');
@@ -217,7 +216,6 @@ export const useStudyStore = defineStore('study', () => {
     importStudy,
     exportStudyConfig,
     exportStudyData,
-    exportStudyCalendar,
     studyUserRoles,
     studyStatus,
     studyId,


### PR DESCRIPTION
The `exportStudyCalendar` function and related UI elements were removed from the codebase. This cleanup eliminates unused functionality, simplifying the component logic and reducing clutter in the studies module.