### PR TITLE
617: loading indicator for downloading study data

### DIFF
--- a/src/components/dialog/ConfirmationDialog.vue
+++ b/src/components/dialog/ConfirmationDialog.vue
@@ -1,19 +1,21 @@
+/* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
+license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
+Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
+Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
+Licensed under the Elastic License 2.0. */
 <script setup lang="ts">
-  /* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
-  license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
-  Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
-  Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
-  Licensed under the Elastic License 2.0. */
-
   import { inject } from 'vue';
   import Button from 'primevue/button';
   import ExclamationIcon from '../shared/ExclamationIcon.vue';
+  import { useI18n } from 'vue-i18n';
+
+  const { t } = useI18n();
 
   const dialogRef: any = inject('dialogRef');
 
-  const message: string = dialogRef.value?.data?.message ?? 'Möchten Sie die Seite wirklich verlassen?';
-  const cancelBtn: string = dialogRef.value?.data?.cancelBtn ?? 'Abbrechen';
-  const approveBtn: string = dialogRef.value?.data?.approveBtn ?? 'Bestätigen';
+  const message: string = dialogRef.value?.data?.message ?? t('global.labels.leavePage');
+  const cancelBtn: string = dialogRef.value?.data?.cancelBtn ?? t('global.labels.cancel');
+  const approveBtn: string = dialogRef.value?.data?.approveBtn ?? t('global.labels.confirm');
 
   function closeDialog(navigate: boolean): void {
     dialogRef.value.close(navigate)

--- a/src/components/dialog/ConfirmationDialog.vue
+++ b/src/components/dialog/ConfirmationDialog.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+  /* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
+  license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
+  Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
+  Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
+  Licensed under the Elastic License 2.0. */
+
+  import { inject } from 'vue';
+  import Button from 'primevue/button';
+  import ExclamationIcon from '../shared/ExclamationIcon.vue';
+
+  const dialogRef: any = inject('dialogRef');
+
+  const message: string = dialogRef.value?.data?.message ?? 'Möchten Sie die Seite wirklich verlassen?';
+  const cancelBtn: string = dialogRef.value?.data?.cancelBtn ?? 'Abbrechen';
+  const approveBtn: string = dialogRef.value?.data?.approveBtn ?? 'Bestätigen';
+
+  function closeDialog(navigate: boolean): void {
+    dialogRef.value.close(navigate)
+  }
+
+</script>
+
+<template>
+
+  <div class="text-base">
+    <div class="mb-8 grid grid-cols-12 place-items-center gap-4">
+      <div class="col-span-2">
+        <ExclamationIcon id="exclamation" />
+      </div>
+      <div class="col-span-10">
+        {{message}}
+      </div>
+    </div>
+    <div class="flex flex-row items-center justify-between">
+      <Button
+        type="button"
+        class="p-button btn-important"
+        :label="approveBtn"
+        @click="closeDialog(true)"
+      />
+      <Button
+        type="button"
+        class="btn-primary"
+        :label="cancelBtn"
+        @click="closeDialog(false)"/>
+    </div>
+  </div>
+
+
+</template>

--- a/src/components/dialog/InfoDialog.vue
+++ b/src/components/dialog/InfoDialog.vue
@@ -1,9 +1,9 @@
-/* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
-license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
-Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
-Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
-Licensed under the Elastic License 2.0. */
 <script setup lang="ts">
+  /* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
+ license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
+ Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
+ Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
+ Licensed under the Elastic License 2.0. */
   import { inject } from 'vue';
   import Button from 'primevue/button';
 

--- a/src/components/dialog/InfoDialog.vue
+++ b/src/components/dialog/InfoDialog.vue
@@ -1,9 +1,9 @@
+/* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
+license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
+Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
+Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
+Licensed under the Elastic License 2.0. */
 <script setup lang="ts">
-  /* Copyright LBI-DHP and/or licensed to LBI-DHP under one or more contributor
- license agreements (LBI-DHP: Ludwig Boltzmann Institute for Digital Health and
- Prevention -- A research institute of the Ludwig Boltzmann Gesellschaft,
- Oesterreichische Vereinigung zur Foerderung der wissenschaftlichen Forschung).
- Licensed under the Elastic License 2.0. */
   import { inject } from 'vue';
   import Button from 'primevue/button';
 

--- a/src/components/subComponents/AuditLogDownload.vue
+++ b/src/components/subComponents/AuditLogDownload.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
-  import { watch, computed } from 'vue';
+  import { watch, computed, ref } from 'vue';
   import { useStudyStore } from '../../stores/studyStore';
   import Button from 'primevue/button';
+  import ProgressSpinner from 'primevue/progressspinner';
 
   const { t } = useI18n();
   const studyStore = useStudyStore();
+  const isLoading = ref<boolean>(false);
 
   const props = defineProps({
     studyId: {
@@ -28,11 +30,15 @@
     }, {immediate: true})
 
   async function getAuditlogMetadata(): Promise<void> {
-     await studyStore.getAuditLogMetadata(studyStore.studyId);
+
+     await studyStore.getAuditLogMetadata(studyStore.studyId)
+
   }
 
   function downloadCurrentAuditlog(): void {
+    isLoading.value = true
     studyStore.exportAuditLog(studyStore.studyId)
+      .then(() => isLoading.value = false);
   }
 </script>
 
@@ -52,10 +58,23 @@
       class="mt-8"
       :label="$t('data.auditLogDownload.btnLabel')"
       @click="downloadCurrentAuditlog()"
-    />
+    >
+      <span class="p-button-icon p-button-icon-left pi pi-download"></span>
+      <span>{{t('data.auditLogDownload.btnLabel')}}</span>
+      <ProgressSpinner
+        v-if="isLoading"
+        class="!text-white ml-2"
+        style="width: 25px; height: 25px"
+        stroke-width="6"
+        fill="transparent"
+        animation-duration=".5s"
+      />
+    </Button>
   </div>
 </template>
 
-<style scoped lang="scss">
-
+<style scoped lang="postcss">
+  :deep(.p-progress-spinner-circle) {
+    stroke: currentColor!important;
+  }
 </style>

--- a/src/components/subComponents/AuditLogDownload.vue
+++ b/src/components/subComponents/AuditLogDownload.vue
@@ -38,7 +38,7 @@
   function downloadCurrentAuditlog(): void {
     isLoading.value = true
     studyStore.exportAuditLog(studyStore.studyId)
-      .then(() => isLoading.value = false);
+      .finally(() => isLoading.value = false);
   }
 </script>
 
@@ -57,6 +57,7 @@
       icon="pi pi-download"
       class="mt-8"
       :label="$t('data.auditLogDownload.btnLabel')"
+      :disabled="isLoading"
       @click="downloadCurrentAuditlog()"
     >
       <span class="p-button-icon p-button-icon-left pi pi-download"></span>

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import Calendar from 'primevue/calendar';
   import Button from 'primevue/button';
-  import { computed, ComputedRef, Ref, ref } from 'vue';
+  import { computed, ComputedRef, onBeforeMount, onBeforeUnmount, Ref, ref } from 'vue';
   import { DropdownOption } from '../../models/Common';
   import { ComponentFactory, Observation, Participant } from '@gs';
   import { AxiosError, AxiosResponse } from 'axios';
@@ -18,6 +18,13 @@
   import MultiSelect from 'primevue/multiselect';
   import { DownloadDataFilter } from '../../models/DataDownloadModel';
   import ProgressSpinner from 'primevue/progressspinner';
+  import { useDialog } from 'primevue/usedialog';
+  import ConfirmationDialog from '../dialog/ConfirmationDialog.vue';
+  import { onBeforeRouteLeave, useRouter } from 'vue-router';
+
+  const dialog = useDialog();
+  const router = useRouter();
+  const pendingRoute = ref<any>(null);
 
   const { t } = useI18n();
   const { componentsApi } = useComponentsApi();
@@ -166,6 +173,62 @@
     .then((response: any) => response.data)
     .then((rs) => (factories = rs))
     .then(loadData);
+
+  function interceptPageNavigation(): void {
+    dialog.open(ConfirmationDialog, {
+      data: {
+        message: t('monitoringData.dialog.msg.downloadStudyData'),
+        cancelBtn: t('monitoringData.dialog.waitForDownload'),
+        approveBtn: t('monitoringData.dialog.navigatePage')
+      },
+      props: {
+        header: t('monitoringData.dialog.header.downloadStudyData'),
+        style: {
+          width: '50vw',
+        },
+        breakpoints: {
+          '960px': '75vw',
+          '640px': '90vw',
+        },
+        modal: true,
+        draggable: false,
+      },
+      onClose: (options) =>{
+        if (options?.data) {
+          if (pendingRoute.value) {
+            isDownloadDataLoading.value = false
+            router.push(pendingRoute.value)
+            pendingRoute.value = null
+          }
+        } else {
+          pendingRoute.value = null
+        }
+        }
+      })
+    }
+
+  onBeforeRouteLeave((to, from, next) => {
+    if (isDownloadDataLoading.value) {
+      pendingRoute.value = to
+      interceptPageNavigation()
+      // preventNavigation
+      next(false)
+    } else {
+      // navigate
+      next()
+    }
+  })
+
+  onBeforeMount(() => {
+    window.addEventListener('beforeunload', (e) => {
+      if (isDownloadDataLoading.value) e.preventDefault() }
+    )
+  })
+  onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', (e) => {
+      if (isDownloadDataLoading.value) e.preventDefault() }
+    )
+  })
 </script>
 
 <template>
@@ -278,6 +341,6 @@
 
 <style scoped lang="postcss">
   :deep(.p-progress-spinner-circle) {
-    stroke: currentColor!important; /* nimmt dann die text-red-600 aus Tailwind */
+    stroke: currentColor!important;
   }
 </style>

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -198,14 +198,12 @@
           if (pendingRoute.value) {
             isDownloadDataLoading.value = false
             router.push(pendingRoute.value)
-            pendingRoute.value = null
           }
-        } else {
-          pendingRoute.value = null
         }
-        }
-      })
-    }
+        pendingRoute.value = null
+      }
+    })
+  }
 
   onBeforeRouteLeave((to, from, next) => {
     if (isDownloadDataLoading.value) {

--- a/src/components/subComponents/DataDownload.vue
+++ b/src/components/subComponents/DataDownload.vue
@@ -17,6 +17,7 @@
   import { useGlobalStore } from '../../stores/globalStore';
   import MultiSelect from 'primevue/multiselect';
   import { DownloadDataFilter } from '../../models/DataDownloadModel';
+  import ProgressSpinner from 'primevue/progressspinner';
 
   const { t } = useI18n();
   const { componentsApi } = useComponentsApi();
@@ -259,9 +260,24 @@
         :label="$t('study.studyList.labels.exportStudyData')"
         :disabled="isDownloadDataLoading"
         @click="downloadStudyData()"
-      />
+      >
+        <span class="p-button-icon p-button-icon-left pi pi-download"></span>
+      <span>{{t('study.studyList.labels.exportStudyData')}}</span>
+        <ProgressSpinner
+          v-if="isDownloadDataLoading"
+          class="!text-white ml-2"
+          style="width: 25px; height: 25px"
+          stroke-width="6"
+          fill="transparent"
+          animation-duration=".5s"
+        />
+      </Button>
     </div>
   </div>
 </template>
 
-<style scoped lang="postcss"></style>
+<style scoped lang="postcss">
+  :deep(.p-progress-spinner-circle) {
+    stroke: currentColor!important; /* nimmt dann die text-red-600 aus Tailwind */
+  }
+</style>

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -125,7 +125,8 @@
       "setPause": "Pausieren",
       "start": "Start",
       "time": "Zeit",
-      "to": "zu"
+      "to": "zu",
+      "leavePage": "Möchten Sie die Seite wirklich verlassen?"
     },
     "placeholder": {
       "all": "Alle",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -392,7 +392,17 @@
       "dataDownload": "Studiendaten herunterladen",
       "lastDataPoints": "Letzte Datenpunkte",
       "recordedObservation": "Erhobene Daten",
-      "auditLog": "AuditLog herunterladen"
+      "auditLog": "Auditlog herunterladen"
+    },
+    "dialog": {
+      "waitForDownload": "Auf Download warten",
+      "navigatePage": "Seite verlassen",
+      "msg": {
+        "downloadStudyData": "Der Daten-Download läuft noch. Sie können die Seite trotzdem verlassen – der Vorgang wird im Hintergrund gebuffert und der Download öffnet sich automatisch in einem neuen Tab, sobald er bereitsteht. Änderungen, die Sie ab jetzt vornehmen, sind darin nicht enthalten."
+      },
+      "header": {
+        "downloadStudyData": "Seite navigieren"
+      }
     }
   },
   "moreTable": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -63,7 +63,7 @@
       "title": "Download study data"
     },
     "auditLogDownload": {
-      "title": "Download AuditLog",
+      "title": "Download Audit log",
       "description": "The number of the current audit log entries is: {length}.",
       "btnLabel": "Download current audit log",
       "notStartedInfo": "Audit log data is only recorded when a study is active.",
@@ -393,6 +393,16 @@
       "lastDataPoints": "Latest Data Points",
       "recordedObservation": "Recorded Observations",
       "auditLog": "Download AuditLog"
+    },
+    "dialog": {
+      "navigatePage": "Leave page",
+      "waitForDownload": "Wait for download",
+      "msg": {
+        "downloadStudyData": "The data download is still in progress. You may leave the page – the process will be buffered in the background and the download will automatically open in a new tab once it is ready. Any changes you make from now on will not be included in this download."
+      },
+      "header": {
+        "downloadStudyData": "Navigate page"
+      }
     }
   },
   "moreTable": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -125,7 +125,8 @@
       "setPause": "Pause",
       "start": "Start",
       "time": "Time",
-      "to": "to"
+      "to": "to",
+      "leavePage": "Do you really want to leave the page?"
     },
     "placeholder": {
       "all": "All",

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,14 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import './index.pcss';
+
+// Tailwind + deine Overrides -> set theme and ovverride with brand colors -> flexibility to switch themes later
+// animations and optimization run over the theme since the last update, so we need a basic theme before overriding it with our brand colors
+import 'primevue/resources/themes/lara-light-blue/theme.css';
+import "primevue/resources/primevue.min.css";
+import '../src/styles/more-light/theme.pcss';
 import '../src/style.pcss';
+
 // PrimeVue
 import PrimeVue from 'primevue/config';
 import Tooltip from 'primevue/tooltip';
@@ -17,11 +24,7 @@ import ConfirmationService from 'primevue/confirmationservice';
 import DialogService from 'primevue/dialogservice';
 import ToastService from 'primevue/toastservice';
 
-// Tailwind + deine Overrides -> set theme and ovverride with brand colors -> flexibility to switch themes later
-// animations and optimization run over the theme since the last update, so we need a basic theme before overriding it with our brand colors
-import 'primevue/resources/themes/lara-light-blue/theme.css';
-import "primevue/resources/primevue.min.css";
-import '../src/styles/more-light/theme.pcss';
+
 
 // Router
 import { Router } from './router';

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,13 @@ import Tooltip from 'primevue/tooltip';
 import ConfirmationService from 'primevue/confirmationservice';
 import DialogService from 'primevue/dialogservice';
 import ToastService from 'primevue/toastservice';
+
+// Tailwind + deine Overrides -> set theme and ovverride with brand colors -> flexibility to switch themes later
+// animations and optimization run over the theme since the last update, so we need a basic theme before overriding it with our brand colors
+import 'primevue/resources/themes/lara-light-blue/theme.css';
+import "primevue/resources/primevue.min.css";
+import '../src/styles/more-light/theme.pcss';
+
 // Router
 import { Router } from './router';
 import AuthService from './service/AuthService';

--- a/src/styles/more-light/theme.pcss
+++ b/src/styles/more-light/theme.pcss
@@ -5867,3 +5867,7 @@
   box-shadow: inset 0 -2px 0 0 var(--primary-color);
 }
 
+:deep(.p-progress-spinner-circle) {
+  stroke: currentColor!important; /* nimmt dann die text-red-600 aus Tailwind */
+}
+


### PR DESCRIPTION
- fixed problem with primevue loading animations
- added loading spinner to download study data button and downlaod auditlog button
- added new confirmation dialog for navigation change
- called new confirmation dialog when user wants do navigate from download study data page to another if downlaod buffer is still going on

note: download functionality will continue, even when user navigates away but some edit functions are locked until the download is completed. the progressbar indicator will show until download starts.

https://github.com/user-attachments/assets/b5da261e-05b1-4215-a074-87115dabf168

Ticket: https://github.com/MORE-Platform/more-studymanager-frontend/issues/617
Assignee: Isabella Aigner